### PR TITLE
Transform old style EDTF dates into new style

### DIFF
--- a/export_test.go
+++ b/export_test.go
@@ -52,7 +52,6 @@ func TestCustomPlacetype(t *testing.T) {
 }
 
 func TestExportEDTF(t *testing.T) {
-
 	ctx := context.Background()
 
 	body := readFeature(t, "1159159407.geojson")
@@ -101,7 +100,45 @@ func TestExportEDTF(t *testing.T) {
 	if bboxStr != "-122.384119,37.615457,-122.384119,37.615457" {
 		t.Fatal("Unexpected geom:bbox")
 	}
+}
 
+func TestExportWithOldStyleEDTFUnknownDates(t *testing.T) {
+	ctx := context.Background()
+	body := readFeature(t, "old-edtf-uuuu-dates.geojson")
+
+	opts, err := NewDefaultOptions(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	wr := bufio.NewWriter(&buf)
+
+	err = Export(body, opts, wr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wr.Flush()
+	body = buf.Bytes()
+
+	cessationProp := gjson.GetBytes(body, "properties.edtf:cessation")
+	if !cessationProp.Exists() {
+		t.Fatalf("missing edtf:cessation property")
+	}
+
+	if cessationProp.String() != "" {
+		t.Fatalf("edtf:cessation not set to new style format")
+	}
+
+	inceptionProp := gjson.GetBytes(body, "properties.edtf:inception")
+	if !inceptionProp.Exists() {
+		t.Fatalf("missing edtf:inception property")
+	}
+
+	if inceptionProp.String() != "" {
+		t.Fatalf("edtf:inception not set to new style format")
+	}
 }
 
 func TestExportWithMissingBelongstoElement(t *testing.T) {

--- a/fixtures/missing-upper-lower-dates.geojson
+++ b/fixtures/missing-upper-lower-dates.geojson
@@ -1,0 +1,60 @@
+{
+  "id": 39312189,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation": "2020-01-01",
+    "edtf:inception": "1990-10",
+    "geom:area": 0,
+    "geom:bbox": "-3.266430,54.209073,-3.266430,54.209073",
+    "geom:latitude": 54.209073,
+    "geom:longitude": -3.26643,
+    "iso:country": "GB",
+    "mz:hierarchy_label": 1,
+    "mz:is_current": 0,
+    "os:country_code": "E92000001",
+    "os:county_code": "E10000006",
+    "os:district_code": "E07000029",
+    "os:positional_quality_indicator": "8",
+    "os:region_code": "E12000002",
+    "src:geom": "os",
+    "wof:belongsto": [
+      404441273,
+      1126001183,
+      404227469,
+      1360698721,
+      85633159,
+      1360698877
+    ],
+    "wof:breaches": [],
+    "wof:country": "GB",
+    "wof:created": 1583800054,
+    "wof:geomhash": "baf2fce02479f2436b6e852bfe2e3eba",
+    "wof:hierarchy": [
+      {
+        "country_id": 85633159,
+        "county_id": 1360698877,
+        "localadmin_id": 404441273,
+        "locality_id": 1126001183,
+        "macroregion_id": 404227469,
+        "postalcode_id": 39312189,
+        "region_id": 1360698721
+      }
+    ],
+    "wof:id": 39312189,
+    "wof:lastmodified": 1595538790,
+    "wof:name": "LA18 4ED",
+    "wof:parent_id": -1,
+    "wof:placetype": "postalcode",
+    "wof:repo": "whosonfirst-data-postalcode-gb",
+    "wof:superseded_by": [],
+    "wof:supersedes": [],
+    "wof:tags": []
+  },
+  "bbox": [
+    -3.26643,
+    54.209073,
+    -3.26643,
+    54.209073
+  ],
+  "geometry": {"coordinates":[-3.26643,54.209073],"type":"Point"}
+}

--- a/fixtures/old-edtf-uuuu-dates.geojson
+++ b/fixtures/old-edtf-uuuu-dates.geojson
@@ -1,0 +1,60 @@
+{
+  "id": 39312189,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation": "uuuu",
+    "edtf:inception": "uuuu",
+    "geom:area": 0,
+    "geom:bbox": "-3.266430,54.209073,-3.266430,54.209073",
+    "geom:latitude": 54.209073,
+    "geom:longitude": -3.26643,
+    "iso:country": "GB",
+    "mz:hierarchy_label": 1,
+    "mz:is_current": 0,
+    "os:country_code": "E92000001",
+    "os:county_code": "E10000006",
+    "os:district_code": "E07000029",
+    "os:positional_quality_indicator": "8",
+    "os:region_code": "E12000002",
+    "src:geom": "os",
+    "wof:belongsto": [
+      404441273,
+      1126001183,
+      404227469,
+      1360698721,
+      85633159,
+      1360698877
+    ],
+    "wof:breaches": [],
+    "wof:country": "GB",
+    "wof:created": 1583800054,
+    "wof:geomhash": "baf2fce02479f2436b6e852bfe2e3eba",
+    "wof:hierarchy": [
+      {
+        "country_id": 85633159,
+        "county_id": 1360698877,
+        "localadmin_id": 404441273,
+        "locality_id": 1126001183,
+        "macroregion_id": 404227469,
+        "postalcode_id": 39312189,
+        "region_id": 1360698721
+      }
+    ],
+    "wof:id": 39312189,
+    "wof:lastmodified": 1595538790,
+    "wof:name": "LA18 4ED",
+    "wof:parent_id": -1,
+    "wof:placetype": "postalcode",
+    "wof:repo": "whosonfirst-data-postalcode-gb",
+    "wof:superseded_by": [],
+    "wof:supersedes": [],
+    "wof:tags": []
+  },
+  "bbox": [
+    -3.26643,
+    54.209073,
+    -3.26643,
+    54.209073
+  ],
+  "geometry": {"coordinates":[-3.26643,54.209073],"type":"Point"}
+}

--- a/properties/edtf.go
+++ b/properties/edtf.go
@@ -42,6 +42,8 @@ func EnsureInception(feature []byte) ([]byte, error) {
 	switch edtf_str {
 	case edtf.UNKNOWN, edtf.OPEN:
 		return feature, nil
+	case edtf.UNKNOWN_2012:
+		return sjson.SetBytes(feature, path, edtf.UNKNOWN)
 	default:
 		// carry on
 	}
@@ -99,6 +101,8 @@ func EnsureCessation(feature []byte) ([]byte, error) {
 	switch edtf_str {
 	case edtf.UNKNOWN, edtf.OPEN:
 		return feature, nil
+	case edtf.UNKNOWN_2012:
+		return sjson.SetBytes(feature, path, edtf.UNKNOWN)
 	default:
 		// carry on
 	}

--- a/properties/edtf.go
+++ b/properties/edtf.go
@@ -7,20 +7,17 @@ import (
 	"github.com/tidwall/sjson"
 )
 
-const date_fmt string = "2006-01-02"
+const dateFmt string = "2006-01-02"
 
 func EnsureEDTF(feature []byte) ([]byte, error) {
-
 	var err error
 
 	feature, err = EnsureInception(feature)
-
 	if err != nil {
 		return nil, err
 	}
 
 	feature, err = EnsureCessation(feature)
-
 	if err != nil {
 		return nil, err
 	}
@@ -29,118 +26,87 @@ func EnsureEDTF(feature []byte) ([]byte, error) {
 }
 
 func EnsureInception(feature []byte) ([]byte, error) {
-
 	path := "properties.edtf:inception"
-	rsp := gjson.GetBytes(feature, path)
+	lowerPath := "properties.date:inception_lower"
+	upperPath := "properties.date:inception_upper"
 
-	if !rsp.Exists() {
-		return sjson.SetBytes(feature, path, edtf.UNKNOWN)
+	return updatePath(feature, path, upperPath, lowerPath)
+}
+
+func EnsureCessation(feature []byte) ([]byte, error) {
+	path := "properties.edtf:cessation"
+	lowerPath := "properties.date:cessation_lower"
+	upperPath := "properties.date:cessation_upper"
+
+	return updatePath(feature, path, upperPath, lowerPath)
+}
+
+func updatePath(feature []byte, path string, upperPath string, lowerPath string) ([]byte, error) {
+	property := gjson.GetBytes(feature, path)
+
+	if !property.Exists() {
+		return setProperties(feature, edtf.UNKNOWN, path, upperPath, lowerPath)
 	}
 
-	edtf_str := rsp.String()
+	edtfStr := property.String()
 
-	switch edtf_str {
+	return setProperties(feature, edtfStr, path, upperPath, lowerPath)
+}
+
+func setProperties(feature []byte, edtfStr string, path string, upperPath, lowerPath string) ([]byte, error) {
+	feature, err := sjson.SetBytes(feature, path, edtfStr)
+	if err != nil {
+		return nil, err
+	}
+
+	switch edtfStr {
 	case edtf.UNKNOWN, edtf.OPEN:
-		return feature, nil
+		return removeUpperLower(feature, upperPath, lowerPath)
 	case edtf.UNKNOWN_2012:
-		return sjson.SetBytes(feature, path, edtf.UNKNOWN)
+		return setProperties(feature, edtf.UNKNOWN, path, upperPath, lowerPath)
 	default:
-		// carry on
+		return setUpperLower(feature, edtfStr, upperPath, lowerPath)
 	}
+}
 
-	d, err := parser.ParseString(edtf_str)
-
+func setUpperLower(feature []byte, edtfStr string, upperPath string, lowerPath string) ([]byte, error) {
+	dt, err := parser.ParseString(edtfStr)
 	if err != nil {
 		return nil, err
 	}
 
-	lower_t, err := d.Lower()
-
+	lowerTime, err := dt.Lower()
 	if err != nil {
 		return nil, err
 	}
 
-	if lower_t != nil {
-
-		feature, err = sjson.SetBytes(feature, "properties.date:inception_lower", lower_t.Format(date_fmt))
-
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	upper_t, err := d.Upper()
-
+	feature, err = sjson.SetBytes(feature, lowerPath, lowerTime.Format(dateFmt))
 	if err != nil {
 		return nil, err
 	}
 
-	if upper_t != nil {
+	upperTime, err := dt.Upper()
+	if err != nil {
+		return nil, err
+	}
 
-		feature, err = sjson.SetBytes(feature, "properties.date:inception_upper", upper_t.Format(date_fmt))
-
-		if err != nil {
-			return nil, err
-		}
+	feature, err = sjson.SetBytes(feature, upperPath, upperTime.Format(dateFmt))
+	if err != nil {
+		return nil, err
 	}
 
 	return feature, nil
 }
 
-func EnsureCessation(feature []byte) ([]byte, error) {
-
-	path := "properties.edtf:cessation"
-	rsp := gjson.GetBytes(feature, path)
-
-	if !rsp.Exists() {
-		return sjson.SetBytes(feature, path, edtf.UNKNOWN)
-	}
-
-	edtf_str := rsp.String()
-
-	switch edtf_str {
-	case edtf.UNKNOWN, edtf.OPEN:
-		return feature, nil
-	case edtf.UNKNOWN_2012:
-		return sjson.SetBytes(feature, path, edtf.UNKNOWN)
-	default:
-		// carry on
-	}
-
-	d, err := parser.ParseString(edtf_str)
-
+func removeUpperLower(feature []byte, upperPath string, lowerPath string) ([]byte, error) {
+	feature, err := sjson.DeleteBytes(feature, upperPath)
 	if err != nil {
 		return nil, err
 	}
 
-	lower_t, err := d.Lower()
-
+	feature, err = sjson.DeleteBytes(feature, lowerPath)
 	if err != nil {
 		return nil, err
-	}
-
-	if lower_t != nil {
-
-		feature, err = sjson.SetBytes(feature, "properties.date:cessation_lower", lower_t.Format(date_fmt))
-
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	upper_t, err := d.Upper()
-
-	if err != nil {
-		return nil, err
-	}
-
-	if upper_t != nil {
-
-		feature, err = sjson.SetBytes(feature, "properties.date:cessation_upper", upper_t.Format(date_fmt))
-
-		if err != nil {
-			return nil, err
-		}
 	}
 
 	return feature, nil


### PR DESCRIPTION
At the moment the library chokes when it tries to export a file containing an old style `uuuu` EDTF date. Let's replace these dates transparently when we see them, making it a bit simpler to work with older files.